### PR TITLE
Publish symbols to nuget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,26 @@ jobs:
         with:
           name: ActiveMQ.Artemis.Client
           path: ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.nupkg
+      - name: Archive NuGet Package With Symbols
+        uses: actions/upload-artifact@v1
+        with:
+          name: ActiveMQ.Artemis.Client
+          path: ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.snupkg
       - name: Publish NuGet Package
-        run: dotnet nuget push ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.nupkg --api-key ${{ secrets.nuget_api_key }} --source https://api.nuget.org/v3/index.json --no-symbols true
+        run: dotnet nuget push ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.nupkg --api-key ${{ secrets.nuget_api_key }} --source https://api.nuget.org/v3/index.json
+      - name: Upload NuGet Package
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.nupkg
+          asset_name: Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.nupkg
+      - name: NuGet Package With Symbols
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./src/ActiveMQ.Artemis.Client/bin/Release/Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.snupkg
+          asset_name: Unofficial.ActiveMQ.Artemis.Client.${{ github.event.release.name }}.snupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           dotnet-version: "3.1.100"
       - name: Create NuGet Package
-        run: dotnet pack -c Release /p:Version=${{ github.event.release.name }} /p:PackageReleaseNotes="See https://github.com/Havret/dotnet-activemq-artemis-client/releases/tag/${{ github.event.release.tag_name }}"
+        run: dotnet pack -c Release /p:Version=${{ github.event.release.name }} /p:PackageReleaseNotes="See https://github.com/Havret/dotnet-activemq-artemis-client/releases/tag/${{ github.event.release.tag_name }}" --commitsha ${{ github.sha }}
       - name: Archive NuGet Package
         uses: actions/upload-artifact@v1
         with:

--- a/src/ActiveMQ.Artemis.Client/ActiveMQ.Artemis.Client.csproj
+++ b/src/ActiveMQ.Artemis.Client/ActiveMQ.Artemis.Client.csproj
@@ -11,6 +11,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Havret/dotnet-activemq-artemis-client</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Havret</Authors>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates release workflow with option to upload symbols alongside with NuGet package. It closes #178.