### PR TITLE
Fix docusaurus workflow

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -32,4 +32,3 @@ jobs:
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: website/build # The folder the action should deploy.
           CLEAN: true
-          CLEAN_EXCLUDE: '["docs", "img"]'


### PR DESCRIPTION
`docs` and `img` dirs should not be excluded from clean. It closes #180. 