### PR TITLE
Connection recovery should not try to handle UnauthorizedAccess

### DIFF
--- a/test/ActiveMQ.Artemis.Client.IntegrationTests/ActiveMQNetIntegrationSpec.cs
+++ b/test/ActiveMQ.Artemis.Client.IntegrationTests/ActiveMQNetIntegrationSpec.cs
@@ -32,7 +32,7 @@ namespace ActiveMQ.Artemis.Client.IntegrationTests
             return connectionFactory.CreateAsync(endpoint);
         }
 
-        private static Endpoint GetEndpoint()
+        protected static Endpoint GetEndpoint()
         {
             string userName = Environment.GetEnvironmentVariable("ARTEMIS_USERNAME") ?? "guest";
             string password = Environment.GetEnvironmentVariable("ARTEMIS_PASSWORD") ?? "guest";

--- a/test/ActiveMQ.Artemis.Client.IntegrationTests/CreateConnectionSpec.cs
+++ b/test/ActiveMQ.Artemis.Client.IntegrationTests/CreateConnectionSpec.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using ActiveMQ.Artemis.Client.Exceptions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ActiveMQ.Artemis.Client.IntegrationTests
+{
+    public class CreateConnectionSpec : ActiveMQNetIntegrationSpec
+    {
+        public CreateConnectionSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_throw_security_exception_when_wrong_credentials_provided_and_connection_auto_recovery_enabled()
+        {
+            var defaultEndpoint = GetEndpoint();
+            var endpoint = Endpoint.Create(
+                password: "wrongPassword",
+                user: defaultEndpoint.User,
+                host: defaultEndpoint.Host,
+                port: defaultEndpoint.Port,
+                scheme: defaultEndpoint.Scheme
+            );
+
+            var connectionFactory = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = true
+            };
+
+            var createConnectionException = await Assert.ThrowsAnyAsync<CreateConnectionException>(() => connectionFactory.CreateAsync(endpoint));
+            Assert.Equal("amqp:unauthorized-access", createConnectionException.ErrorCode);
+        }
+    }
+}


### PR DESCRIPTION
UnauthorizedAccess (amqp:unauthorized-access) is not a transient exception. There is no point in trying to reconnect when this exception occurs, as it may give the impression that the client freezes on start. 