### PR TITLE
Revert AMQPNetLite upgrade

### DIFF
--- a/src/ArtemisNetClient/ArtemisNetClient.csproj
+++ b/src/ArtemisNetClient/ArtemisNetClient.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.4.6" />
-    <PackageReference Include="AMQPNetLite.WebSockets" Version="2.4.6" />
+    <PackageReference Include="AMQPNetLite" Version="2.4.5" />
+    <PackageReference Include="AMQPNetLite.WebSockets" Version="2.4.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
     <PackageReference Include="Polly" Version="7.2.1" />


### PR DESCRIPTION
Following the upgrade of AMQPNetLite in task #457, tests occasionally hang indefinitely. We should revert this change until we can pinpoint the underlying issue.