### PR TITLE
Fix unauthorized producer creation attempts cause log flooding and unresponsiveness

### DIFF
--- a/src/ArtemisNetClient/ProducerBase.cs
+++ b/src/ArtemisNetClient/ProducerBase.cs
@@ -136,6 +136,10 @@ namespace ActiveMQ.Artemis.Client
             }
             if (_senderLink.IsDetaching() || _senderLink.IsClosed)
             {
+                if (_senderLink.Error != null)
+                {
+                    throw new ProducerClosedException(_senderLink.Error.Description, _senderLink.Error.Condition, null);
+                }
                 throw new ProducerClosedException();
             }
         }


### PR DESCRIPTION
It closes #477.