### PR TITLE
Enhance Modify and Reject dispositions

### DIFF
--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Exceptions;
 using ActiveMQ.Artemis.Client.Transactions;
 using Amqp;
+using Amqp.Framing;
 using Microsoft.Extensions.Logging;
 using Nito.AsyncEx;
 
@@ -63,11 +64,18 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             return _consumer.AcceptAsync(message, transaction, cancellationToken);
         }
 
-        public void Reject(Message message, bool undeliverableHere)
+        public void Modify(Message message, bool deliveryFailed, bool undeliverableHere)
         {
             CheckState();
 
-            _consumer.Reject(message, undeliverableHere);
+            _consumer.Modify(message, deliveryFailed, undeliverableHere);
+        }
+
+        public void Reject(Message message, Error error = null)
+        {
+            CheckState();
+
+            _consumer.Reject(message, error);
         }
 
         private void CheckState()

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Exceptions;
 using ActiveMQ.Artemis.Client.Transactions;
 using Amqp;
-using Amqp.Framing;
 using Microsoft.Extensions.Logging;
 using Nito.AsyncEx;
 
@@ -71,11 +70,11 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             _consumer.Modify(message, deliveryFailed, undeliverableHere);
         }
 
-        public void Reject(Message message, Error error = null)
+        public void Reject(Message message)
         {
             CheckState();
 
-            _consumer.Reject(message, error);
+            _consumer.Reject(message);
         }
 
         private void CheckState()

--- a/src/ArtemisNetClient/Consumer.cs
+++ b/src/ArtemisNetClient/Consumer.cs
@@ -84,11 +84,11 @@ namespace ActiveMQ.Artemis.Client
             Log.MessageModified(_logger, message, _receiverLink);
         }
 
-        public void Reject(Message message, Error error = null)
+        public void Reject(Message message)
         {
             CheckState();
 
-            _receiverLink.Reject(message.InnerMessage, error: error);
+            _receiverLink.Reject(message.InnerMessage);
             Log.MessageRejected(_logger, message, _receiverLink);
         }
 

--- a/src/ArtemisNetClient/Consumer.cs
+++ b/src/ArtemisNetClient/Consumer.cs
@@ -76,11 +76,19 @@ namespace ActiveMQ.Artemis.Client
             Log.MessageAccepted(_logger, message, _receiverLink);
         }
 
-        public void Reject(Message message, bool undeliverableHere)
+        public void Modify(Message message, bool deliveryFailed, bool undeliverableHere)
         {
             CheckState();
-            
-            _receiverLink.Modify(message.InnerMessage, deliveryFailed: true, undeliverableHere: undeliverableHere);
+
+            _receiverLink.Modify(message.InnerMessage, deliveryFailed: deliveryFailed, undeliverableHere: undeliverableHere);
+            Log.MessageModified(_logger, message, _receiverLink);
+        }
+
+        public void Reject(Message message, Error error = null)
+        {
+            CheckState();
+
+            _receiverLink.Reject(message.InnerMessage, error: error);
             Log.MessageRejected(_logger, message, _receiverLink);
         }
 
@@ -160,6 +168,11 @@ namespace ActiveMQ.Artemis.Client
                 0,
                 "Message accepted. MessageId: '{0}' ConsumerName: '{1}'.");
 
+            private static readonly Action<ILogger, object, string, Exception> _messageModified = LoggerMessage.Define<object, string>(
+                LogLevel.Trace,
+                0,
+                "Message modified. MessageId: '{0}' ConsumerName: '{1}'.");
+
             private static readonly Action<ILogger, object, string, Exception> _messageRejected = LoggerMessage.Define<object, string>(
                 LogLevel.Trace,
                 0,
@@ -200,6 +213,14 @@ namespace ActiveMQ.Artemis.Client
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
                     _messageAccepted(logger, message.GetMessageId<object>(), receiverLink.Name, null);
+                }
+            }
+
+            public static void MessageModified(ILogger logger, Message message, ReceiverLink receiverLink)
+            {
+                if (logger.IsEnabled(LogLevel.Trace))
+                {
+                    _messageModified(logger, message.GetMessageId<object>(), receiverLink.Name, null);
                 }
             }
 

--- a/src/ArtemisNetClient/IConsumer.cs
+++ b/src/ArtemisNetClient/IConsumer.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Transactions;
+using Amqp.Framing;
 
 namespace ActiveMQ.Artemis.Client
 {
@@ -9,6 +10,7 @@ namespace ActiveMQ.Artemis.Client
     {
         ValueTask<Message> ReceiveAsync(CancellationToken cancellationToken = default);
         ValueTask AcceptAsync(Message message, Transaction transaction, CancellationToken cancellationToken = default);
-        void Reject(Message message, bool undeliverableHere = false);
+        void Modify(Message message, bool deliveryFailed, bool undeliverableHere);
+        void Reject(Message message, Error error = null);
     }
 }

--- a/src/ArtemisNetClient/IConsumer.cs
+++ b/src/ArtemisNetClient/IConsumer.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Transactions;
-using Amqp.Framing;
 
 namespace ActiveMQ.Artemis.Client
 {
@@ -11,6 +10,6 @@ namespace ActiveMQ.Artemis.Client
         ValueTask<Message> ReceiveAsync(CancellationToken cancellationToken = default);
         ValueTask AcceptAsync(Message message, Transaction transaction, CancellationToken cancellationToken = default);
         void Modify(Message message, bool deliveryFailed, bool undeliverableHere);
-        void Reject(Message message, Error error = null);
+        void Reject(Message message);
     }
 }

--- a/test/ArtemisNetClient.IntegrationTests/MessageAcknowledgementSpec.cs
+++ b/test/ArtemisNetClient.IntegrationTests/MessageAcknowledgementSpec.cs
@@ -34,7 +34,7 @@ namespace ActiveMQ.Artemis.Client.IntegrationTests
         }
 
         [Fact]
-        public async Task Should_redeliver_message_to_the_same_consumer_when_message_rejected()
+        public async Task Should_redeliver_message_to_the_same_consumer_when_message_modified()
         {
             await using var connection = await CreateConnection();
             var address = Guid.NewGuid().ToString();
@@ -43,14 +43,14 @@ namespace ActiveMQ.Artemis.Client.IntegrationTests
 
             await producer.SendAsync(address, RoutingType.Anycast, new Message("foo"));
             var msg = await consumer.ReceiveAsync();
-            consumer.Reject(msg);
+            consumer.Modify(msg, deliveryFailed: true, undeliverableHere: false);
 
             msg = await consumer.ReceiveAsync(new CancellationTokenSource(TimeSpan.FromMilliseconds(500)).Token);
             Assert.Equal("foo", msg.GetBody<string>());
         }
         
         [Fact]
-        public async Task Should_redeliver_message_to_different_consumer_when_message_rejected_with_undeliverableHere_flag_enabled()
+        public async Task Should_redeliver_message_to_different_consumer_when_message_modified_with_undeliverableHere_flag_enabled()
         {
             await using var connection = await CreateConnection();
             var address = Guid.NewGuid().ToString();
@@ -59,13 +59,39 @@ namespace ActiveMQ.Artemis.Client.IntegrationTests
 
             await producer.SendAsync(address, RoutingType.Anycast, new Message("foo"));
             var msg = await consumer1.ReceiveAsync();
-            consumer1.Reject(msg, undeliverableHere: true);
+            consumer1.Modify(msg, deliveryFailed: true, undeliverableHere: true);
             
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await consumer1.ReceiveAsync(new CancellationTokenSource(TimeSpan.FromMilliseconds(100)).Token));
             
             var consumer2 = await connection.CreateConsumerAsync(address, RoutingType.Anycast);
             msg = await consumer2.ReceiveAsync(new CancellationTokenSource(TimeSpan.FromMilliseconds(500)).Token);
             Assert.Equal("foo", msg.GetBody<string>());
+        }
+
+        [Fact]
+        public async Task Should_deliver_message_to_DLQ_when_message_rejected()
+        {
+            await using var connection = await CreateConnection();
+            var address = Guid.NewGuid().ToString();
+            await using var producer = await connection.CreateAnonymousProducerAsync();
+            var consumer1 = await connection.CreateConsumerAsync(address, RoutingType.Anycast);
+
+            string messageId = Guid.NewGuid().ToString();
+            await producer.SendAsync(address, RoutingType.Anycast, new Message("foo") 
+            {
+                MessageId = messageId
+            });
+            var msg = await consumer1.ReceiveAsync();
+            consumer1.Reject(msg);
+
+            await consumer1.DisposeAsync();
+
+            var consumer2 = await connection.CreateConsumerAsync("DLQ", RoutingType.Anycast);
+            var rejectedMsg = await consumer2.ReceiveAsync();
+            await consumer2.AcceptAsync(rejectedMsg);
+
+            Assert.Equal(messageId, msg.MessageId);
+            Assert.Equal(messageId, rejectedMsg.MessageId);
         }
     }
 }

--- a/test/ArtemisNetClient.IntegrationTests/MessageDeliveryCountSpec.cs
+++ b/test/ArtemisNetClient.IntegrationTests/MessageDeliveryCountSpec.cs
@@ -36,10 +36,27 @@ namespace ActiveMQ.Artemis.Client.IntegrationTests
 
             await producer.SendAsync(new Message("foo"));
             var msg = await consumer1.ReceiveAsync(CancellationToken);
-            consumer1.Reject(msg);
+            consumer1.Modify(msg, deliveryFailed: true, undeliverableHere: true);
 
             var msg2 = await consumer2.ReceiveAsync(CancellationToken);
             Assert.Equal(1u, msg2.DeliveryCount);
+        }
+
+        [Fact]
+        public async Task Should_receive_msg_with_DeliveryCount_set_to_0_when_msg_was_modified_with_deliveryFailed_set_to_false()
+        {
+            await using var connection = await CreateConnection();
+            var address = Guid.NewGuid().ToString();
+            await using var producer = await connection.CreateProducerAsync(address, RoutingType.Anycast);
+            await using var consumer1 = await connection.CreateConsumerAsync(address, RoutingType.Anycast);
+            await using var consumer2 = await connection.CreateConsumerAsync(address, RoutingType.Anycast);
+
+            await producer.SendAsync(new Message("foo"));
+            var msg = await consumer1.ReceiveAsync(CancellationToken);
+            consumer1.Modify(msg, deliveryFailed: false, undeliverableHere: true);
+
+            var msg2 = await consumer2.ReceiveAsync(CancellationToken);
+            Assert.Equal(0u, msg2.DeliveryCount);
         }
     }
 }

--- a/test/ArtemisNetClient.UnitTests/ConsumerMessageAcknowledgementSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/ConsumerMessageAcknowledgementSpec.cs
@@ -86,18 +86,10 @@ namespace ActiveMQ.Artemis.Client.UnitTests
             messageSource.Enqueue(new Message("foo"));
             var message = await consumer.ReceiveAsync();
 
-            var condition = new Amqp.Types.Symbol("a condition");
-            var description = "an error description";
-            Error error = new(condition)
-            {
-                Description = description
-            };
-            consumer.Reject(message, error: error);
+            consumer.Reject(message);
 
             var dispositionContext = messageSource.GetNextDisposition(Timeout);
             Assert.IsType<Rejected>(dispositionContext.DeliveryState);
-            Assert.Equal(condition, ((Rejected)dispositionContext.DeliveryState).Error.Condition);
-            Assert.Equal(description, ((Rejected)dispositionContext.DeliveryState).Error.Description);
             Assert.True(dispositionContext.Settled);
         }
     }


### PR DESCRIPTION
Related discussion: #518 

# What's Changed
1. Introduced a `Modify` method for Consumers, which will send `Modify` dispositions, allowing the user to configure the `deliveryFailed` and the `undeliverableHere` flags.
2. Changed the `Rejected` implementation to actually call the AMQP's `Reject` method which sends a `Reject` disposition. By default, the `Error` is set to null, but is left configurable, if the user needs to add that info.
3. Adapted and introduced new Unit and Integration tests.

**Tests run**:
![image](https://github.com/user-attachments/assets/b6558ed3-a7fc-47e9-b026-b892326e6cca)
