### PR TITLE
Fix flaky AutoRecoveringProducer send-before-recovery race

### DIFF
--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducer.cs
@@ -23,10 +23,11 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             while (true)
             {
                 CheckState();
+                var producer = _producer;
 
                 try
                 {
-                    await _producer.SendAsync(message, transaction, cancellationToken).ConfigureAwait(false);
+                    await producer.SendAsync(message, transaction, cancellationToken).ConfigureAwait(false);
                     return;
                 }
                 catch (ProducerClosedException e) when (e.ErrorCode == ErrorCode.UnauthorizedAccess)
@@ -42,6 +43,12 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                     await WaitAsync(cancellationToken).ConfigureAwait(false);
                     Log.RetryingSendAsync(Logger, _configuration.Address);
                 }
+                catch (ObjectDisposedException) when (!ReferenceEquals(producer, _producer))
+                {
+                    HandleProducerClosed();
+                    await WaitAsync(cancellationToken).ConfigureAwait(false);
+                    Log.RetryingSendAsync(Logger, _configuration.Address);
+                }
             }
         }
 
@@ -50,13 +57,20 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             while (true)
             {
                 CheckState();
+                var producer = _producer;
 
                 try
                 {
-                    _producer.Send(message, cancellationToken);
+                    producer.Send(message, cancellationToken);
                     return;
                 }
                 catch (ProducerClosedException)
+                {
+                    HandleProducerClosed();
+                    Wait(cancellationToken);
+                    Log.RetryingSendAsync(Logger, _configuration.Address);
+                }
+                catch (ObjectDisposedException) when (!ReferenceEquals(producer, _producer))
                 {
                     HandleProducerClosed();
                     Wait(cancellationToken);

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
@@ -112,7 +112,7 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
             Assert.Throws<ProducerClosedException>(() => producer.Send(new Message("foo"), cts.Token));
         }
 
-        [Fact(Skip = "Flaky in CI: intermittent ObjectDisposedException (ProducerBase) when send is invoked before connection restoration. Tracked in GH-554.")]
+        [Fact]
         public async Task Should_be_able_to_Send_message_when_Send_invoked_before_connection_restored()
         {
             var endpoint = GetUniqueEndpoint();


### PR DESCRIPTION
## Summary
This PR fixes the flaky unit test from GH-554 where sync send could intermittently fail with ObjectDisposedException during connection recovery, and re-enables the previously skipped test.

## Root cause
During recovery, the auto-recovering wrapper can swap the underlying producer reference and dispose the old instance.
A send call that started just before or during that swap could hit the disposed old producer and throw ObjectDisposedException before recovery had fully resumed.

## Fix
Updated AutoRecoveringProducer.cs in both SendAsync and Send paths to:

- Snapshot the current underlying producer before calling send.
- Retry recovery only when ObjectDisposedException is from a stale producer instance that has already been swapped out.
- Keep existing behavior for legitimate terminal/closed scenarios.

This is implemented with a reference check guard to ensure we only retry for the swap race window.

## Test updates
Re-enabled the flaky test by removing Skip:
- AutoRecoveringProducerSpec.cs

Re-enabled test:
- Should_be_able_to_Send_message_when_Send_invoked_before_connection_restored

## Validation
Executed targeted and stress validation:

- Filtered tests including AutoRecoveringProducerSpec and ClosedProducerSpec: passed.
- Repeated flaky test 20 times:
  - runs: 20
  - failures: 0

## Behavior and compatibility
- No API surface changes.
- Retry behavior is narrowly scoped to stale-instance disposal during recovery.
- Normal disposed/closed semantics remain intact.

## Closes
Closes #554