### PR TITLE
Fix recovery loop spin on persistent link and connection failures

### DIFF
--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConnection.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConnection.cs
@@ -31,6 +31,7 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
         private readonly ConcurrentHashSet<IRecoverable> _recoverables = new();
         private readonly CancellationTokenSource _recoveryCancellationToken = new();
         private readonly AsyncRetryPolicy<IConnection> _connectionRetryPolicy;
+        private readonly IRecoveryPolicy _recoveryPolicy;
         private readonly Task _recoveryLoopTask;
 
         public AutoRecoveringConnection(ILoggerFactory loggerFactory,
@@ -54,6 +55,7 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             _writer = channel.Writer;
 
             _connectionRetryPolicy = CreateConnectionRetryPolicy(recoveryPolicy);
+            _recoveryPolicy = recoveryPolicy;
 
             _recoveryLoopTask = StartRecoveryLoop();
         }
@@ -90,14 +92,24 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
         {
             return Task.Run(async () =>
             {
+                int attempt = 0;
                 try
                 {
                     while (true)
                     {
                         await _reader.ReadAsync(_recoveryCancellationToken.Token).ConfigureAwait(false);
+                        while (_reader.TryRead(out _)) { } // drain duplicates - each recoverable also signals on connection loss
 
                         if (!IsOpened)
                         {
+                            if (attempt > 0)
+                            {
+                                var delay = _recoveryPolicy.GetDelay(attempt);
+                                if (delay > TimeSpan.Zero)
+                                    await Task.Delay(delay, _recoveryCancellationToken.Token).ConfigureAwait(false);
+                            }
+                            attempt++;
+
                             await DisposeInnerConnection().ConfigureAwait(false);
 
                             foreach (var recoverable in _recoverables.Values)
@@ -129,10 +141,21 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                         }
                         else
                         {
-                            // If the connection is already opened it means that there may be some suspended recoverables that need to be resumed
+                            // Connection is open, but a link was closed - try to re-establish it
+                            attempt = 0;
+
                             foreach (var recoverable in _recoverables.Values)
                             {
-                                recoverable.Resume();
+                                try
+                                {
+                                    await recoverable.RecoverAsync(_connection, _recoveryCancellationToken.Token).ConfigureAwait(false);
+                                    recoverable.Resume();
+                                }
+                                catch (Exception e)
+                                {
+                                    _recoverables.Remove(recoverable);
+                                    await recoverable.TerminateAsync(e).ConfigureAwait(false);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #562 

## Problem

Two bugs in the recovery loop cause it to spin indefinitely.

**Bug 1 - `else` branch (primary):** When the connection is up but a producer's link gets closed by the broker (e.g. the target address doesn't exist) the loop just wakes the producer up and lets it retry. The send fails again the link closes again and the whole thing repeats forever.

**Bug 2 - `!IsOpened` branch (secondary):** When the connection drops and comes back quickly TCP can succeed while the broker immediately closes the AMQP layer. Since `CreateAsync()` didn't throw Polly doesn't apply any backoff and the loop keeps hammering the broker.

On top of that every active producer and consumer each write their own recovery command to the channel when the connection drops causing extra unnecessary iterations.

## Fix

- **`else` branch** - instead of just waking the producer up try to re-create the link. If that fails terminate the producer so the error gets thrown to the caller.
- **`!IsOpened` branch** - keep track of how many times we've retried and apply `recoveryPolicy.GetDelay(attempt)` before each attempt so the backoff actually kicks in.
- **Channel drain** - discard duplicate commands queued up for the same disconnect so we don't process it more than once.