### PR TITLE
Fix auto-recovery behavior for AMQ119002 producer failures

### DIFF
--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringAnonymousProducer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringAnonymousProducer.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Exceptions;
 using ActiveMQ.Artemis.Client.Transactions;
+using Amqp;
 using Microsoft.Extensions.Logging;
 
 namespace ActiveMQ.Artemis.Client.AutoRecovering
@@ -28,6 +29,13 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                     await _producer.SendAsync(address, routingType, message, transaction, cancellationToken).ConfigureAwait(false);
                     return;
                 }
+                catch (ProducerClosedException e) when (e.ErrorCode is ErrorCode.UnauthorizedAccess)
+                {
+                    await TerminateAsync(e).ConfigureAwait(false);
+
+                    // Producer cannot be recovered when broker denies authorization.
+                    throw;
+                }
                 catch (ProducerClosedException)
                 {
                     HandleProducerClosed();
@@ -47,6 +55,13 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                 {
                     _producer.Send(address, routingType, message, cancellationToken);
                     return;
+                }
+                catch (ProducerClosedException e) when (e.ErrorCode is ErrorCode.UnauthorizedAccess)
+                {
+                    TerminateAsync(e).GetAwaiter().GetResult();
+
+                    // Producer cannot be recovered when broker denies authorization.
+                    throw;
                 }
                 catch (ProducerClosedException)
                 {

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConnection.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConnection.cs
@@ -116,7 +116,6 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                                 }
                                 catch (Exception e)
                                 {
-                                    _recoverables.Remove(recoverable);
                                     await recoverable.TerminateAsync(e).ConfigureAwait(false);
                                 }
                             }

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringConsumer.cs
@@ -134,6 +134,7 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             _manualResetEvent.Set();
             Log.ConsumerTerminated(_logger, exception);
             await DisposeUnderlyingConsumerSafe(_consumer).ConfigureAwait(false);
+            Closed?.Invoke(this);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducer.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducer.cs
@@ -30,11 +30,11 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                     await producer.SendAsync(message, transaction, cancellationToken).ConfigureAwait(false);
                     return;
                 }
-                catch (ProducerClosedException e) when (e.ErrorCode == ErrorCode.UnauthorizedAccess)
+                catch (ProducerClosedException e) when (IsTerminalProducerException(e))
                 {
                     await TerminateAsync(e).ConfigureAwait(false);
-                    
-                    // Producer does not have permissions to send on specified address 
+
+                    // Producer cannot be recovered for terminal broker-side close reasons.
                     throw;
                 }
                 catch (ProducerClosedException)
@@ -64,6 +64,13 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                     producer.Send(message, cancellationToken);
                     return;
                 }
+                catch (ProducerClosedException e) when (IsTerminalProducerException(e))
+                {
+                    TerminateAsync(e).GetAwaiter().GetResult();
+
+                    // Producer cannot be recovered for terminal broker-side close reasons.
+                    throw;
+                }
                 catch (ProducerClosedException)
                 {
                     HandleProducerClosed();
@@ -77,6 +84,11 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
                     Log.RetryingSendAsync(Logger, _configuration.Address);
                 }
             }
+        }
+
+        private static bool IsTerminalProducerException(ProducerClosedException exception)
+        {
+            return exception.ErrorCode is ErrorCode.UnauthorizedAccess or ErrorCode.NotFound;
         }
 
         protected override IAsyncDisposable UnderlyingResource => _producer;

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducerBase.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringProducerBase.cs
@@ -80,6 +80,7 @@ namespace ActiveMQ.Artemis.Client.AutoRecovering
             _manualResetEvent.Set();
             Log.ProducerTerminated(Logger, exception);
             await DisposeResourceSafe(UnderlyingResource).ConfigureAwait(false);
+            Closed?.Invoke(this);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/ArtemisNetClient/AutoRecovering/AutoRecoveringRequestReplyClient.cs
+++ b/src/ArtemisNetClient/AutoRecovering/AutoRecoveringRequestReplyClient.cs
@@ -105,11 +105,13 @@ internal class AutoRecoveringRequestReplyClient : IRequestReplyClient, IRecovera
         _failureCause = exception;
         _manualResetEvent.Set();
         await DisposeUnderlyingRpcClientSafe(_requestReplyClient).ConfigureAwait(false);
+        Closed?.Invoke(this);
     }
 
     public async ValueTask DisposeAsync()
     {
         await DisposeUnderlyingRpcClient(_requestReplyClient).ConfigureAwait(false);
+        Closed?.Invoke(this);
     }
 
     private async Task DisposeUnderlyingRpcClientSafe(IRequestReplyClient requestReplyClient)

--- a/src/ArtemisNetClient/ProducerBase.cs
+++ b/src/ArtemisNetClient/ProducerBase.cs
@@ -59,7 +59,10 @@ namespace ActiveMQ.Artemis.Client
             }
             else if (link.IsDetaching() || link.IsClosed)
             {
-                tcs.TrySetException(new ProducerClosedException());
+                var error = link.Error;
+                tcs.TrySetException(error != null
+                    ? new ProducerClosedException(error.Description, error.Condition, null)
+                    : new ProducerClosedException());
             }
             else if (outcome.Descriptor.Code == MessageOutcomes.Rejected.Descriptor.Code)
             {

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringAnonymousProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringAnonymousProducerSpec.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using ActiveMQ.Artemis.Client.Exceptions;
+using ActiveMQ.Artemis.Client.InternalUtilities;
 using ActiveMQ.Artemis.Client.UnitTests.Utils;
 using Amqp;
 using Amqp.Framing;
@@ -81,6 +83,58 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
 
             Assert.Throws<ProducerClosedException>(() =>
                 producer.Send("a2", null, new Message("bar"), CancellationToken));
+        }
+        [Fact]
+        public async Task Should_not_recreate_anonymous_producer_on_connection_recovery_after_terminal_unauthorized_access_error()
+        {
+            var endpoint = GetUniqueEndpoint();
+            var producerAttached = new ManualResetEvent(false);
+            var testHandler = new TestHandler(@event =>
+            {
+                switch (@event.Id)
+                {
+                    case EventId.LinkRemoteOpen when @event.Context is Attach attach && attach.Role:
+                        producerAttached.Set();
+                        break;
+                }
+            });
+
+            var host1 = CreateOpenedContainerHost(endpoint, testHandler);
+            var linkProcessor = host1.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            var connection = await CreateConnection(endpoint);
+            var producer = await connection.CreateAnonymousProducerAsync();
+
+            Assert.True(producerAttached.WaitOne(Timeout));
+            producerAttached.Reset();
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(ErrorCode.UnauthorizedAccess) { Description = "Unauthorized" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            // SendAsync triggers TerminateAsync which should remove the producer from the recovery set.
+            await Assert.ThrowsAsync<ProducerClosedException>(() =>
+                producer.SendAsync("a1", null, new Message("foo"), null, CancellationToken));
+
+            host1.Dispose();
+            using var host2 = CreateOpenedContainerHost(endpoint, testHandler);
+
+            // Producer should NOT be recreated after connection recovery.
+            Assert.False(producerAttached.WaitOne(ShortTimeout));
+
+            await DisposeUtil.DisposeAll(connection, host2);
         }
     }
 }

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringAnonymousProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringAnonymousProducerSpec.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using ActiveMQ.Artemis.Client.Exceptions;
+using ActiveMQ.Artemis.Client.UnitTests.Utils;
+using Amqp;
+using Amqp.Framing;
+using Amqp.Handler;
+using Amqp.Listener;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
+{
+    public class AutoRecoveringAnonymousProducerSpec : ActiveMQNetSpec
+    {
+        public AutoRecoveringAnonymousProducerSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_terminate_anonymous_producer_on_SendAsync_when_link_closed_with_unauthorized_access()
+        {
+            using var host = CreateOpenedContainerHost();
+            var linkProcessor = host.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateAnonymousProducerAsync();
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(ErrorCode.UnauthorizedAccess) { Description = "Unauthorized" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var exception = await Assert.ThrowsAsync<ProducerClosedException>(() =>
+                producer.SendAsync("a1", null, new Message("foo"), null, CancellationToken));
+            Assert.Equal(ErrorCode.UnauthorizedAccess, exception.ErrorCode);
+
+            await Assert.ThrowsAsync<ProducerClosedException>(() =>
+                producer.SendAsync("a2", null, new Message("bar"), null, CancellationToken));
+        }
+
+        [Fact]
+        public async Task Should_terminate_anonymous_producer_on_Send_when_link_closed_with_unauthorized_access()
+        {
+            using var host = CreateOpenedContainerHost();
+            var linkProcessor = host.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateAnonymousProducerAsync();
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(ErrorCode.UnauthorizedAccess) { Description = "Unauthorized" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var exception = Assert.Throws<ProducerClosedException>(() =>
+                producer.Send("a1", null, new Message("foo"), CancellationToken));
+            Assert.Equal(ErrorCode.UnauthorizedAccess, exception.ErrorCode);
+
+            Assert.Throws<ProducerClosedException>(() =>
+                producer.Send("a2", null, new Message("bar"), CancellationToken));
+        }
+    }
+}

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
@@ -215,7 +215,7 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
         [Fact]
         public async Task Should_not_retry_SendAsync_when_producer_link_closed_with_not_found()
         {
-            var host = CreateOpenedContainerHost();
+            using var host = CreateOpenedContainerHost();
             var linkProcessor = host.CreateTestLinkProcessor();
 
             ListenerLink producerLink = null;
@@ -247,7 +247,7 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
         [Fact]
         public async Task Should_not_retry_Send_when_producer_link_closed_with_not_found()
         {
-            var host = CreateOpenedContainerHost();
+            using var host = CreateOpenedContainerHost();
             var linkProcessor = host.CreateTestLinkProcessor();
 
             ListenerLink producerLink = null;

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
@@ -276,6 +276,58 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
             Assert.Throws<ProducerClosedException>(() => producer.Send(new Message("bar"), CancellationToken));
         }
 
+        [Fact]
+        public async Task Should_not_recreate_producer_on_connection_recovery_after_terminal_not_found_error()
+        {
+            var endpoint = GetUniqueEndpoint();
+            var producerAttached = new ManualResetEvent(false);
+            var testHandler = new TestHandler(@event =>
+            {
+                switch (@event.Id)
+                {
+                    case EventId.LinkRemoteOpen when @event.Context is Attach attach && attach.Role:
+                        producerAttached.Set();
+                        break;
+                }
+            });
+
+            var host1 = CreateOpenedContainerHost(endpoint, testHandler);
+            var linkProcessor = host1.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            var connection = await CreateConnection(endpoint);
+            var producer = await connection.CreateProducerAsync("a1", RoutingType.Anycast);
+
+            Assert.True(producerAttached.WaitOne(Timeout));
+            producerAttached.Reset();
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(Amqp.ErrorCode.NotFound) { Description = "AMQ119002: target address a1 does not exist" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            // SendAsync triggers TerminateAsync which should remove the producer from the recovery set.
+            await Assert.ThrowsAsync<ProducerClosedException>(() => producer.SendAsync(new Message("foo"), CancellationToken));
+
+            host1.Dispose();
+            using var host2 = CreateOpenedContainerHost(endpoint, testHandler);
+
+            // Producer should NOT be recreated after connection recovery.
+            Assert.False(producerAttached.WaitOne(ShortTimeout));
+
+            await DisposeUtil.DisposeAll(connection, host2);
+        }
+
         private async Task<(IProducer producer, MessageProcessor messageProcessor, TestContainerHost host, IConnection connection)> CreateReattachedProducer()
         {
             var endpoint = GetUniqueEndpoint();

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringProducerSpec.cs
@@ -5,8 +5,10 @@ using ActiveMQ.Artemis.Client.AutoRecovering.RecoveryPolicy;
 using ActiveMQ.Artemis.Client.Exceptions;
 using ActiveMQ.Artemis.Client.InternalUtilities;
 using ActiveMQ.Artemis.Client.UnitTests.Utils;
+using Amqp;
 using Amqp.Framing;
 using Amqp.Handler;
+using Amqp.Listener;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -208,6 +210,70 @@ namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
             using var host2 = CreateOpenedContainerHost(endpoint, testHandler);
 
             Assert.False(producerAttached.WaitOne(ShortTimeout));
+        }
+
+        [Fact]
+        public async Task Should_not_retry_SendAsync_when_producer_link_closed_with_not_found()
+        {
+            var host = CreateOpenedContainerHost();
+            var linkProcessor = host.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateProducerAsync("a1", RoutingType.Anycast);
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(Amqp.ErrorCode.NotFound) { Description = "AMQ119002: target address a1 does not exist" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var exception = await Assert.ThrowsAsync<ProducerClosedException>(() => producer.SendAsync(new Message("foo"), CancellationToken));
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+
+            // Once terminated, subsequent sends should fail immediately with ProducerClosedException.
+            await Assert.ThrowsAsync<ProducerClosedException>(() => producer.SendAsync(new Message("bar"), CancellationToken));
+        }
+
+        [Fact]
+        public async Task Should_not_retry_Send_when_producer_link_closed_with_not_found()
+        {
+            var host = CreateOpenedContainerHost();
+            var linkProcessor = host.CreateTestLinkProcessor();
+
+            ListenerLink producerLink = null;
+            linkProcessor.SetHandler(context =>
+            {
+                producerLink = context.Link;
+                return false;
+            });
+
+            await using var connection = await CreateConnection(host.Endpoint);
+            var producer = await connection.CreateProducerAsync("a1", RoutingType.Anycast);
+
+            try
+            {
+                await producerLink.CloseAsync(Timeout, new Error(ErrorCode.NotFound) { Description = "AMQ119002: target address a1 does not exist" });
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var exception = Assert.Throws<ProducerClosedException>(() => producer.Send(new Message("foo"), CancellationToken));
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+
+            // Once terminated, subsequent sends should fail immediately with ProducerClosedException.
+            Assert.Throws<ProducerClosedException>(() => producer.Send(new Message("bar"), CancellationToken));
         }
 
         private async Task<(IProducer producer, MessageProcessor messageProcessor, TestContainerHost host, IConnection connection)> CreateReattachedProducer()

--- a/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringRequestReplyClientSpec.cs
+++ b/test/ArtemisNetClient.UnitTests/AutoRecovering/AutoRecoveringRequestReplyClientSpec.cs
@@ -1,0 +1,56 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ActiveMQ.Artemis.Client.InternalUtilities;
+using ActiveMQ.Artemis.Client.UnitTests.Utils;
+using Amqp.Framing;
+using Amqp.Handler;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ActiveMQ.Artemis.Client.UnitTests.AutoRecovering
+{
+    public class AutoRecoveringRequestReplyClientSpec : ActiveMQNetSpec
+    {
+        public AutoRecoveringRequestReplyClientSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Should_not_recreate_disposed_request_reply_clients()
+        {
+            var endpoint = GetUniqueEndpoint();
+            var linksAttached = new CountdownEvent(2);
+            var connectionRecovered = new ManualResetEvent(false);
+            var testHandler = new TestHandler(@event =>
+            {
+                switch (@event.Id)
+                {
+                    case EventId.LinkRemoteOpen when @event.Context is Attach:
+                        linksAttached.Signal();
+                        break;
+                }
+            });
+
+            var host1 = CreateOpenedContainerHost(endpoint, testHandler);
+
+            var connection = await CreateConnection(endpoint);
+            connection.ConnectionRecovered += (_, _) => connectionRecovered.Set();
+            var rpcClient = await connection.CreateRequestReplyClientAsync();
+
+            Assert.True(linksAttached.Wait(Timeout));
+            await rpcClient.DisposeAsync();
+
+            linksAttached.Reset();
+
+            await DisposeHostAndWaitUntilConnectionNotified(host1, connection);
+
+            var host2 = CreateOpenedContainerHost(endpoint, testHandler);
+
+            Assert.True(connectionRecovered.WaitOne(Timeout));
+
+            Assert.False(linksAttached.Wait(ShortTimeout));
+
+            await DisposeUtil.DisposeAll(connection, host2);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Havret/dotnet-activemq-artemis-client/issues/562